### PR TITLE
Small changes

### DIFF
--- a/cgi/List_Status.php
+++ b/cgi/List_Status.php
@@ -234,7 +234,7 @@ $(document).ready(function()
        echo "\n<td> ".$row["Uptime"] ." </td>";
        echo "\n<td " . ($row["Auth_Valid"]?"":"class=\"Issue\"") . " > ".$row["Auth"]." </td>";
        echo "\n<td> ".$row["Serial_Number"]." </td>";
-       echo "\n<td> ".$row["Firmware_Version"]." </td>";
+       echo "\n<td " . ($row["Firmware_Valid"]?"":"class=\"Issue\"") . " > ".$row["Firmware_Version"]." </td>";
 
        echo "\n<td ". ($row["Reciever_Type_Valid"]?"":"class=\"Issue\"")." > ";
        switch ($row["Reciever_Type"]) {
@@ -261,6 +261,9 @@ $(document).ready(function()
             break;
           case "138":
             echo "SPS356";
+            break;
+          case "112":
+            echo "Ag542";
             break;
           case "162":
             echo "Alloy";
@@ -360,6 +363,9 @@ $(document).ready(function()
             break;
           case "570":
             echo "Zephyr 3 Base";
+            break;
+          case "758":
+            echo "R780-2";
             break;
 
           default:

--- a/cgi/List_Status.php
+++ b/cgi/List_Status.php
@@ -41,21 +41,17 @@ $(document).ready(function()
 <H1>GNSS Receivers</H1>
 
 <?php
-if ($_REQUEST["User_ID"]) {
-    $user_id = gnss_require_user_id(new SQLite3($databaseFile));
-    echo '<input name="User_ID" type="hidden" value="'.h($user_id).'">';
-    }
-else {
-    die ("Internal Error: Missing User ID");
-   }
-?>
-
-
-<?php
    error_reporting(E_ALL);
    include 'error.php.inc';
    include 'db.inc.php';
    include 'security.inc.php';
+
+   $user_id = gnss_require_user_id(new SQLite3($databaseFile));
+   echo '<input name="User_ID" type="hidden" value="'.h($user_id).'">';
+?>
+
+
+<?php
 
 
    function ntrip_summary_html($row)

--- a/cgi/Status_Update.py
+++ b/cgi/Status_Update.py
@@ -291,6 +291,7 @@ def check_firmware_and_password(GNSS_ID, DB, HTTP):
         return False
 
 RECEIVER_FIRMWARE_COLUMNS = {
+    "112": "GamelFile",
     "162": "AlloyFile",
     "169": "ChinstrapFile",
     "188": "BarracudaFile",
@@ -325,6 +326,8 @@ def check_firmware(GNSS_ID, FirmwareVersions, DB, HTTP):
             + " Skipping firmware version check: no firmware file configured for receiver type "
             + str(DB.Reciever_Type)
         )
+        DB.STATUS.execute("UPDATE STATUS SET Firmware_Valid=? where id=?", (True, GNSS_ID))
+        DB.conn.commit()
         return (True, "")
 
     Firmware_Version_Base = 0.0
@@ -347,6 +350,9 @@ def check_firmware(GNSS_ID, FirmwareVersions, DB, HTTP):
     firmwareValid = True
     Message = ""
     firmwareType = 1 # Everything is Titan now
+
+    if (DB.Reciever_Type == "112"):
+        firmwareType = 0
 
     if (DB.Reciever_Type == "162"):
         firmwareType = 1
@@ -374,6 +380,8 @@ def check_firmware(GNSS_ID, FirmwareVersions, DB, HTTP):
         firmwareValid = Firmware_Version == FirmwareVersions[DB.Firmware][firmwareType]
         Message = "Receiver Firmware is " + Firmware_Version + " Should be " + FirmwareVersions[DB.Firmware][firmwareType] + " Ring " + DB.Firmware + "\n"
 
+    DB.STATUS.execute("UPDATE STATUS SET Firmware_Valid=? where id=?", (firmwareValid, GNSS_ID))
+    DB.conn.commit()
     return(firmwareValid, Message)
 
 

--- a/cgi/Upgrade_GNSS.py
+++ b/cgi/Upgrade_GNSS.py
@@ -58,7 +58,7 @@ else:
 # Fetch firmware filenames
 # Note: The original code does not select 'AlloyFile' in this query,
 # but tries to use it later. Ensure AlloyFile is defined in db_inc.py or add it to this query.
-query = 'SELECT Titan_Version, AlloyFile, BarracudaFile, ChinstrapFile, ClarkFile, KryptonFile, LancetFile FROM Firmware where type=?'
+query = 'SELECT Titan_Version, AlloyFile, BarracudaFile, ChinstrapFile, ClarkFile, KryptonFile, LancetFile, GamelFile FROM Firmware where type=?'
 cursor.execute(query, (Firmware_ID,))
 
 rows = cursor.fetchone()
@@ -74,6 +74,7 @@ ChinstrapFile = rows[3]
 ClarkFile = rows[4]
 KryptonFile = rows[5]
 LancetFile = rows[6]
+GamelFile = rows[7]
 
 print("Upgrading to firmware V" + str(Firmware) + "<br/>")
 
@@ -124,6 +125,9 @@ for row in rows:
       elif Reciever_Type == 101:
          print("SPS985 ", end=" ")
          print("Not Supported")
+      elif Reciever_Type == 112:
+         print("Ag542 ", end=" ")
+         firmware_file = GamelFile
       elif Reciever_Type == 162:
          print("Alloy ", end=" ")
          firmware_file = AlloyFile

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,8 @@ if [ "$(id -u)" -ne 0 ]; then
    exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 WWW=/var/www/html/Dashboard
 CGI=/usr/lib/cgi-bin/Dashboard
 WWW_USER=www-data
@@ -37,12 +39,16 @@ if [ ! -f $CGI/secret_key ]; then
 fi
 
 if command -v pip3 >/dev/null; then
-    REQ="$(dirname "$0")/requirements.txt"
-    PIP3=(pip3 install -r "$REQ")
-    if pip3 install --help 2>&1 | grep -q break-system-packages; then
-        PIP3=(pip3 install --break-system-packages -r "$REQ")
+    REQ="$SCRIPT_DIR/requirements.txt"
+    if [ ! -f "$REQ" ]; then
+        echo "Warning: requirements file not found: $REQ" >&2
+    else
+        PIP3=(pip3 install -r "$REQ")
+        if pip3 install --help 2>&1 | grep -q break-system-packages; then
+            PIP3=(pip3 install --break-system-packages -r "$REQ")
+        fi
+        "${PIP3[@]}" || true
     fi
-    "${PIP3[@]}" || true
 fi
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,12 @@ if [ ! -f $CGI/secret_key ]; then
 fi
 
 if command -v pip3 >/dev/null; then
-    pip3 install -r "$(dirname "$0")/requirements.txt" || true
+    REQ="$(dirname "$0")/requirements.txt"
+    PIP3=(pip3 install -r "$REQ")
+    if pip3 install --help 2>&1 | grep -q break-system-packages; then
+        PIP3=(pip3 install --break-system-packages -r "$REQ")
+    fi
+    "${PIP3[@]}" || true
 fi
 
 

--- a/www/Edit_GNSS.php
+++ b/www/Edit_GNSS.php
@@ -151,7 +151,7 @@ Receiver:
 </td><td>
 <select required name=Receiver_Type>
   <option value="162" <?php echo ($row["Reciever_Type"]=="138")?"selected":"" ?>>Alloy</option>
-  <option value="112" <?php echo ($row["Reciever_Type"]=="112")?"selected":"" ?>>AgGPS_542</option>
+  <option value="112" <?php echo ($row["Reciever_Type"]=="112")?"selected":"" ?>>Ag542</option>
   <option value="240" <?php echo ($row["Reciever_Type"]=="240")?"selected":"" ?>>BD935</option>
   <option value="164" <?php echo ($row["Reciever_Type"]=="164")?"selected":"" ?>>BX992-INS</option>
   <option value="508" <?php echo ($row["Reciever_Type"]=="508")?"selected":"" ?>>BX992-MS</option>

--- a/www/Receiver_List.php
+++ b/www/Receiver_List.php
@@ -99,6 +99,9 @@ $(document).ready(function()
        echo "\n<td> ".$row["Port"]." </td>";
        echo "\n<td> ";
        switch ($row["Reciever_Type"]) {
+          case "112":
+            echo "Ag542";
+            break;
           case "162":
             echo "Alloy";
             break;

--- a/www/Receiver_List.php
+++ b/www/Receiver_List.php
@@ -38,15 +38,16 @@ $(document).ready(function()
 <form name="input" action="Edit_GNSS.php" method="get">
 
 <?php
-$user_id = gnss_require_user_id(new SQLite3($databaseFile));
-echo '<input name="User_ID" type="hidden" value="'.h($user_id).'">';
+   include 'error.php.inc';
+   include 'db.inc.php';
+   include 'security.inc.php';
+
+   $user_id = gnss_require_user_id(new SQLite3($databaseFile));
+   echo '<input name="User_ID" type="hidden" value="'.h($user_id).'">';
 ?>
 
 
 <?php
-   include 'error.php.inc';
-   include 'db.inc.php';
-   include 'security.inc.php';
 
 
    function displayGNSS($result, $user_id)


### PR DESCRIPTION
## Summary
- Fix blank `List_Status.php` / `Receiver_List.php` by loading security includes before calling `gnss_require_user_id()`.
- Highlight invalid firmware in red on the status dashboard by persisting and displaying `Firmware_Valid`.
- Add receiver type **112 (Ag542)** with Gamel firmware mapping for upgrade/status checks (no fw_upload changes).
- Add antenna type **758 (R780-2)** to the status table display.
- Harden `setup.sh` for PEP 668 systems: use `--break-system-packages` when supported, and resolve `requirements.txt` from the script directory so pip works after `cd` into the CGI path.

