### PR TITLE
Fix receiver and antenna display names on status and edit pages.

### DIFF
--- a/cgi/List_Status.php
+++ b/cgi/List_Status.php
@@ -299,7 +299,7 @@ $(document).ready(function()
             echo "R780-2";
             break;
           case "330":
-            echo "MP1086";
+            echo "MP86";
             break;
           case "331":
             echo "MS1086";
@@ -332,7 +332,7 @@ $(document).ready(function()
             echo "GA830";
             break;
           case "784":
-            echo "MP1086";
+            echo "MP86";
             break;
           case "146":
             echo "R10";
@@ -366,6 +366,9 @@ $(document).ready(function()
             break;
           case "758":
             echo "R780-2";
+            break;
+          case "721":
+            echo "R780";
             break;
 
           default:

--- a/www/Edit_GNSS.php
+++ b/www/Edit_GNSS.php
@@ -294,7 +294,7 @@ Type:
   <option value="147" <?php echo ($row["Antenna"]=="147"?"selected":""); ?>>SPS985</option>
   <option value="569" <?php echo ($row["Antenna"]=="569"?"selected":""); ?>>SPS986</option>
   <option value="569" <?php echo ($row["Antenna"]=="146"?"selected":""); ?>>R10</option>
-  <option value="721" <?php echo ($row["Antenna"]=="751"?"selected":""); ?>>R780</option>
+  <option value="721" <?php echo ($row["Antenna"]=="721"?"selected":""); ?>>R780</option>
   <option value="758" <?php echo ($row["Antenna"]=="758"?"selected":""); ?>>R780-2</option>
   <option value="184" <?php echo ($row["Antenna"]=="184"?"selected":""); ?>>Zephyr 2</option>
   <option value="185" <?php echo ($row["Antenna"]=="185"?"selected":""); ?>>Zephyr Geodetic 2</option>


### PR DESCRIPTION
Use MP86 for type 330, add antenna 721 as R780, and fix R780 selection in Edit_GNSS.